### PR TITLE
Add missing 'description' property to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@
 authors = ["Max Bridgland <mabridgland@protonmail.com>"]
 name = "pixcryption"
 version = "0.0.1"
+description = "📷 Pixel Safe Encryption - Now Cryptographically Secure 🔒"
 [tool.poetry.dependencies]
 numpy = "*"
 pillow = "*"


### PR DESCRIPTION
Merging this PR will enable the use of `poetry install` to install the project via Poetry [per the documentation](https://github.com/M4cs/pixcryption/blob/4f547ae32a0a0b123a4a502df45a68cba01cc5af/README.md#development).

Fixes #12 